### PR TITLE
Marketplace-first UI: real product images, dense Amazon-style grids

### DIFF
--- a/src/app/components/ProductCard.tsx
+++ b/src/app/components/ProductCard.tsx
@@ -5,7 +5,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { FaCheck, FaShoppingCart } from 'react-icons/fa';
-import { FiExternalLink, FiShield } from 'react-icons/fi';
 import type { Product, ProductRatingStats } from '@/types';
 import { useAuth } from '../context/AuthContext';
 import { useProductInStack, usePriceCalculations } from '@/hooks';
@@ -29,7 +28,6 @@ interface ProductCardProps {
 }
 
 export default function ProductCard({ product, ratingStats: initialStats }: ProductCardProps) {
-  const [isHovered, setIsHovered] = useState(false);
   const [isCheckoutOpen, setIsCheckoutOpen] = useState(false);
   const [ratingStats, setRatingStats] = useState<ProductRatingStats | null>(initialStats || null);
   const { user } = useAuth();
@@ -42,7 +40,7 @@ export default function ProductCard({ product, ratingStats: initialStats }: Prod
   const { isStartingCheckout, startCheckout } = useCommerceCheckout();
 
   // Use custom hook for price calculations
-  const { costPerServing, monthlyCost } = usePriceCalculations(
+  const { costPerServing } = usePriceCalculations(
     product.product_price,
     product.servings_per_container,
     product.servings_per_day
@@ -103,124 +101,87 @@ export default function ProductCard({ product, ratingStats: initialStats }: Prod
   };
 
   return (
-    <div
-      className="group flex h-full flex-col overflow-hidden rounded-lg border border-gray-100 bg-white transition-colors duration-150 hover:border-gray-300 animate-fade-in"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
+    <div className="group flex h-full flex-col overflow-hidden rounded border border-gray-200 bg-white transition-all duration-150 hover:border-gray-300 hover:shadow-md">
       {/* Clickable Product Link - wraps image and basic info */}
       <Link href={`/product/${productId}`} className="block">
         {/* Product Image */}
-        <div className="relative h-64 overflow-hidden border-b border-gray-100 bg-gray-50">
+        <div className="relative aspect-square overflow-hidden bg-white">
           {product.product_image ? (
             <Image
               src={product.product_image}
               alt={product.product_name}
               fill
-              className="object-contain p-5 transition-transform duration-300 group-hover:scale-[1.03]"
+              className="object-contain p-4 transition-transform duration-300 group-hover:scale-[1.04]"
             />
           ) : (
             <div className="flex items-center justify-center h-full">
-              <div className="flex h-20 w-20 items-center justify-center rounded-full border border-gray-200 bg-white">
-                <span className="text-2xl font-semibold text-gray-900">
-                  {product.product_name.charAt(0)}
-                </span>
-              </div>
+              <span className="text-3xl font-semibold text-gray-300">
+                {product.product_name.charAt(0)}
+              </span>
             </div>
           )}
 
-          <div className="absolute left-3 top-3">
+          <div className="absolute left-2 top-2">
             <Badge variant={purchaseDestination.channel === 'shopify' || purchaseDestination.channel === 'shopify_ucp' ? 'success' : 'primary'}>
-              {purchaseDestination.mode === 'shopify_checkout'
-                ? 'Shopify checkout'
-                : purchaseDestination.mode === 'shopify_cart_permalink'
-                ? 'Shopify cart'
-                : purchaseDestination.mode === 'shopify_ucp_candidate'
-                ? 'Shopify UCP'
-                : purchaseDestination.mode === 'shopify_discovery'
+              {purchaseDestination.channel === 'shopify' || purchaseDestination.channel === 'shopify_ucp'
                 ? 'Shopify'
                 : inventoryLabel}
             </Badge>
           </div>
-
-          <div className="absolute bottom-3 left-3 rounded bg-gray-900 px-3 py-1.5 text-sm font-semibold text-white">
-            ${formatPrice(product.product_price)}
-          </div>
         </div>
 
         {/* Product Info (clickable) */}
-        <div className="p-5 pb-0">
-          <div className="mb-2 text-sm font-medium text-gray-500">
-            {product.brands?.brand_name || 'Premium Brand'}
-          </div>
-
-          <h3 className="mb-3 font-serif text-xl text-gray-900 line-clamp-2">
+        <div className="border-t border-gray-100 p-3 pb-0">
+          <p className="text-xs text-gray-500">{product.brands?.brand_name || 'Premium Brand'}</p>
+          <h3 className="mt-0.5 text-sm font-medium leading-5 text-gray-900 line-clamp-2 group-hover:underline">
             {product.product_name}
           </h3>
 
-          <div className="flex items-center gap-2 mb-4">
-            <Rating value={rating} size="md" />
-            <span className="text-sm font-medium text-gray-600">
-              {rating > 0 ? `${Number(rating).toFixed(1)} (${reviewCount.toLocaleString()})` : 'No reviews yet'}
+          <div className="mt-1 flex items-center gap-1.5">
+            <Rating value={rating} size="sm" />
+            {reviewCount > 0 && (
+              <span className="text-xs text-gray-500">({reviewCount.toLocaleString()})</span>
+            )}
+          </div>
+
+          <div className="mt-1.5 flex items-baseline gap-2">
+            <span className="text-lg font-semibold text-gray-900">
+              ${formatPrice(product.product_price)}
+            </span>
+            <span className="text-xs text-gray-500">
+              ${formatPrice(costPerServing)}/serving
             </span>
           </div>
         </div>
       </Link>
 
       {/* Non-clickable actions section */}
-      <div className="flex flex-1 flex-col px-5 pb-5">
-        <div className="grid grid-cols-2 gap-3 mb-4 text-xs">
-          <div className="rounded border border-gray-100 bg-gray-50 p-3 text-center">
-            <div className="font-semibold text-gray-900">${formatPrice(costPerServing)}</div>
-            <div className="text-gray-500">per serving</div>
-          </div>
-          <div className="rounded border border-gray-100 bg-gray-50 p-3 text-center">
-            <div className="font-semibold text-gray-900">${formatPrice(monthlyCost)}</div>
-            <div className="text-gray-500">per month</div>
-          </div>
-        </div>
+      <div className="mt-auto flex flex-col gap-2 p-3">
+        <Button
+          variant="primary"
+          size="sm"
+          fullWidth
+          onClick={handleStartCheckout}
+          disabled={!canPurchase(product)}
+          isLoading={isStartingCheckout}
+        >
+          {purchaseLabel}
+        </Button>
 
-        <div className="mb-3 text-xs font-medium text-gray-500">
-          {product.servings_per_container} servings • {product.servings_per_day} per day recommended
-        </div>
-
-        {product.quality_badges && product.quality_badges.length > 0 && (
-          <div className="mb-4 flex flex-wrap gap-2">
-            {product.quality_badges.slice(0, 2).map((badge) => (
-              <span key={badge} className="inline-flex items-center gap-1 rounded border border-gray-100 px-2 py-1 text-xs text-gray-600">
-                <FiShield className="h-3 w-3" />
-                {badge}
-              </span>
-            ))}
-          </div>
-        )}
-
-        <div className="mt-auto space-y-3">
+        {!isCatalogProduct && (
           <Button
-            variant="primary"
+            onClick={handleAddToStack}
+            disabled={isInStack || isUpdating}
+            variant={isInStack ? 'outline' : 'ghost'}
+            size="sm"
             fullWidth
-            onClick={handleStartCheckout}
-            disabled={!canPurchase(product)}
-            isLoading={isStartingCheckout}
-            rightIcon={<FiExternalLink />}
+            leftIcon={isInStack ? <FaCheck className="w-3.5 h-3.5" /> : <FaShoppingCart className="w-3.5 h-3.5" />}
+            isLoading={isUpdating}
+            className={isInStack ? 'bg-success-50 text-success-700 border-success-200 hover:bg-success-100' : ''}
           >
-            {purchaseLabel}
+            {isInStack ? 'In Stack' : 'Add to Stack'}
           </Button>
-
-          {!isCatalogProduct && (
-            <Button
-              onClick={handleAddToStack}
-              disabled={isInStack || isUpdating}
-              variant={isInStack ? 'outline' : 'ghost'}
-              fullWidth
-              leftIcon={isInStack ? <FaCheck className="w-4 h-4" /> : <FaShoppingCart className="w-4 h-4" />}
-              isLoading={isUpdating}
-              className={isInStack ? 'bg-success-50 text-success-700 border-success-200 hover:bg-success-100' : ''}
-            >
-              {isInStack ? 'Added to Stack' : 'Add to My Stack'}
-            </Button>
-          )}
-        </div>
+        )}
       </div>
 
       <EmbeddedCheckout

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,19 +2,12 @@
 
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
-import { FiArrowRight, FiBarChart2, FiLayers, FiShoppingBag } from 'react-icons/fi';
 import { useSupplements } from '@/hooks';
 import { brandSlug, buildBrandDiscovery } from '@/lib/catalog/brand-discovery';
-import { formatCurrency } from '@/lib/utils';
-import { SkeletonGrid, SkeletonCard, Stack, Inline } from '@/components/ui';
+import { SkeletonGrid, SkeletonCard, Inline, Stack } from '@/components/ui';
 import { EnhancedSearchBar } from '@/components/composite/Search';
 import { CategoryFilter, SortFilter } from '@/components/composite/Filter';
 import { SupplementGrid, FeaturedCategories } from '@/components/composite/Supplement';
-
-const heroBackgroundStyle = {
-  backgroundImage:
-    'linear-gradient(90deg, rgba(255,255,255,0.97) 0%, rgba(255,255,255,0.9) 48%, rgba(255,255,255,0.34) 100%), url(https://images.unsplash.com/photo-1517836357463-d25dfeac3438?w=1600&h=900&fit=crop)',
-};
 
 export default function Home() {
   const [searchTerm, setSearchTerm] = useState('');
@@ -27,80 +20,22 @@ export default function Home() {
     sortBy: sortBy as 'name' | 'popular',
   });
   const brandHighlights = useMemo(
-    () => buildBrandDiscovery(supplements).slice(0, 4),
+    () => buildBrandDiscovery(supplements).slice(0, 6),
     [supplements]
   );
-  const averageMonthlySpend = supplements.length
-    ? supplements.reduce((sum, supplement) => sum + (supplement.average_price ?? 0), 0) /
-      supplements.length
-    : 0;
 
   return (
     <div className="min-h-screen bg-white">
-      {/* Hero Section */}
-      <div className="border-b border-gray-200">
-        <div
-          className="bg-cover bg-center"
-          style={heroBackgroundStyle}
-        >
-          <div className="max-w-6xl mx-auto px-4 py-14 lg:py-20">
-            <div className="max-w-2xl">
-              <p className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-4">
-                Protein, creatine, pre-workout, recovery
-              </p>
-              <h1 className="text-4xl lg:text-6xl font-serif text-gray-900 mb-6">
-                SuppStack
-              </h1>
-              <p className="text-lg lg:text-xl text-gray-600 leading-relaxed">
-                Build a gym stack you can actually maintain. Compare whey, creatine, pre-workout,
-                recovery, and refill-ready products, then move into Shopify purchase paths when
-                it is time to restock.
-              </p>
-
-              <div className="flex flex-col sm:flex-row gap-3 mt-8">
-                <Link
-                  href="/login"
-                  className="inline-flex h-11 items-center justify-center gap-2 rounded bg-gray-900 px-6 text-sm font-medium text-white hover:bg-gray-800"
-                >
-                  Build your stack
-                  <FiArrowRight />
-                </Link>
-                <Link
-                  href="/brands"
-                  className="inline-flex h-11 items-center justify-center rounded border border-gray-200 bg-white px-6 text-sm font-medium text-gray-700 hover:border-gray-300 hover:bg-gray-50"
-                >
-                  Shop brands
-                </Link>
-              </div>
-
-              <div className="w-full max-w-xl mt-8">
-                <EnhancedSearchBar value={searchTerm} onChange={setSearchTerm} />
-              </div>
-
-              <div className="grid grid-cols-3 gap-5 pt-8">
-                <div>
-                  <p className="text-2xl font-serif text-gray-900">{supplements.length}+</p>
-                  <p className="text-sm text-gray-500">Gym products</p>
-                </div>
-                <div>
-                  <p className="text-2xl font-serif text-gray-900">{brandHighlights.length * 3}+</p>
-                  <p className="text-sm text-gray-500">Brand lanes</p>
-                </div>
-                <div>
-                  <p className="text-2xl font-serif text-gray-900">
-                    {formatCurrency(averageMonthlySpend)}
-                  </p>
-                  <p className="text-sm text-gray-500">Avg. restock</p>
-                </div>
-              </div>
-            </div>
-          </div>
+      {/* Search bar — the storefront entry point */}
+      <div className="border-b border-gray-200 bg-white">
+        <div className="mx-auto max-w-7xl px-4 py-4">
+          <EnhancedSearchBar value={searchTerm} onChange={setSearchTerm} />
         </div>
       </div>
 
-      {/* Navigation & Filters */}
-      <div className="border-b border-gray-100 sticky top-[65px] z-40 bg-white">
-        <div className="max-w-6xl mx-auto px-4 py-3">
+      {/* Filters */}
+      <div className="sticky top-[65px] z-40 border-b border-gray-100 bg-white">
+        <div className="mx-auto max-w-7xl px-4 py-2.5">
           <Inline justify="between" align="center" wrap gap={4}>
             <CategoryFilter
               supplements={supplements}
@@ -117,36 +52,21 @@ export default function Home() {
         </div>
       </div>
 
-      {/* Main Content */}
-      <div className="max-w-6xl mx-auto px-4 py-12">
+      {/* Products first */}
+      <div className="mx-auto max-w-7xl px-4 py-6">
         {isLoading ? (
-          <SkeletonGrid count={12} CardComponent={SkeletonCard} />
+          <SkeletonGrid count={15} CardComponent={SkeletonCard} />
         ) : (
-          <Stack gap={16}>
+          <Stack gap={10}>
             <section>
-              <div className="grid md:grid-cols-3 gap-4">
-                <div className="border border-gray-200 rounded p-5">
-                  <FiLayers className="text-gray-500 mb-4" />
-                  <h2 className="text-xl font-serif text-gray-900">Build gym stacks</h2>
-                  <p className="text-sm text-gray-600 mt-2">
-                    Save protein, creatine, pump, recovery, and hydration products in one repeatable plan.
-                  </p>
-                </div>
-                <div className="border border-gray-200 rounded p-5">
-                  <FiBarChart2 className="text-gray-500 mb-4" />
-                  <h2 className="text-xl font-serif text-gray-900">Know the monthly burn</h2>
-                  <p className="text-sm text-gray-600 mt-2">
-                    Compare serving cost, monthly restock spend, and subscription-friendly picks.
-                  </p>
-                </div>
-                <div className="border border-gray-200 rounded p-5">
-                  <FiShoppingBag className="text-gray-500 mb-4" />
-                  <h2 className="text-xl font-serif text-gray-900">Restock without friction</h2>
-                  <p className="text-sm text-gray-600 mt-2">
-                    Jump from product research to Shopify discovery, brand stores, and refill paths.
-                  </p>
-                </div>
+              <SupplementGrid supplements={filteredSupplements} />
+            </section>
+
+            <section>
+              <div className="section-header">
+                <h2>Shop by Training Goal</h2>
               </div>
+              <FeaturedCategories supplements={supplements} />
             </section>
 
             <section>
@@ -156,62 +76,36 @@ export default function Home() {
                   View all
                 </Link>
               </Inline>
-              <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
                 {brandHighlights.map((brand) => (
                   <Link
                     key={brand.brandName}
                     href={`/brands/${brandSlug(brand.brandName)}`}
-                    className="border border-gray-200 rounded p-4 hover:border-gray-300 transition-colors"
+                    className="rounded border border-gray-200 p-3 text-center transition-colors hover:border-gray-300 hover:bg-gray-50"
                   >
-                    <p className="font-medium text-gray-900">{brand.brandName}</p>
-                    <p className="text-sm text-gray-500 mt-1">
-                      {brand.productCount} listings from {formatCurrency(brand.averagePrice)}
-                    </p>
-                    <p className="text-xs text-gray-500 mt-3 line-clamp-1">
-                      {brand.categories.slice(0, 3).join(' / ')}
-                    </p>
+                    <p className="truncate text-sm font-medium text-gray-900">{brand.brandName}</p>
+                    <p className="mt-0.5 text-xs text-gray-500">{brand.productCount} products</p>
                   </Link>
                 ))}
               </div>
-            </section>
-
-            {/* Featured Categories */}
-            <section>
-              <div className="section-header">
-                <h2>Shop by Training Goal</h2>
-              </div>
-              <FeaturedCategories supplements={supplements} />
-            </section>
-
-            {/* Product Grid */}
-            <section>
-              <div className="section-header">
-                <h2>All Gym Supplements</h2>
-              </div>
-              <SupplementGrid supplements={filteredSupplements} />
             </section>
           </Stack>
         )}
       </div>
 
       {/* Footer */}
-      <footer className="border-t border-gray-200 mt-16">
-        <div className="max-w-6xl mx-auto px-4 py-12">
-          <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
-            <div>
-              <p className="text-xl font-serif text-gray-900">SuppStack</p>
-              <p className="text-sm text-gray-500 mt-1">
-                Gym stacks, refill math, and Shopify-ready supplement discovery.
-              </p>
-            </div>
+      <footer className="mt-10 border-t border-gray-200">
+        <div className="mx-auto max-w-7xl px-4 py-8">
+          <div className="flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
+            <p className="text-sm text-gray-500">SuppStack — supplement marketplace</p>
             <div className="flex gap-8 text-sm text-gray-500">
-              <a href="/terms" className="hover:text-gray-900 transition-colors">
+              <a href="/terms" className="transition-colors hover:text-gray-900">
                 Terms
               </a>
-              <a href="/privacy" className="hover:text-gray-900 transition-colors">
+              <a href="/privacy" className="transition-colors hover:text-gray-900">
                 Privacy
               </a>
-              <a href="/contact" className="hover:text-gray-900 transition-colors">
+              <a href="/contact" className="transition-colors hover:text-gray-900">
                 Contact
               </a>
             </div>

--- a/src/app/supplement/[id]/page.tsx
+++ b/src/app/supplement/[id]/page.tsx
@@ -171,14 +171,14 @@ export default function SupplementPage({ params }: { params: { id: string } }) {
       {/* Back Navigation */}
       <Link
         href="/"
-        className="inline-flex items-center gap-2 text-gray-600 hover:text-gray-900 mb-6 transition-colors"
+        className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 mb-4 transition-colors"
       >
         <FiArrowLeft />
-        <span>Back to Stack Shop</span>
+        <span>All products</span>
       </Link>
 
       {/* Header */}
-      <Stack gap={2} className="mb-8">
+      <Stack gap={2} className="mb-6">
         <div className="flex flex-wrap items-center gap-2">
           {supplement.category && (
             <span className="rounded border border-gray-200 px-2 py-1 text-xs font-medium text-gray-600">
@@ -191,31 +191,19 @@ export default function SupplementPage({ params }: { params: { id: string } }) {
             </span>
           )}
         </div>
-        <h1 className="text-4xl font-serif text-gray-900">
+        <h1 className="text-3xl font-serif text-gray-900">
           {supplement.supplement_name}
         </h1>
-        <p className="text-xl text-gray-600">{supplement.supplement_description}</p>
-        {(supplement.common_dosage || !!supplement.primary_goals?.length) && (
-          <div className="grid grid-cols-1 gap-3 border-y border-gray-100 py-4 text-sm md:grid-cols-2">
-            {supplement.common_dosage && (
-              <div>
-                <div className="font-semibold text-gray-900">Typical dose</div>
-                <div className="text-gray-600">{supplement.common_dosage}</div>
-              </div>
-            )}
-            {!!supplement.primary_goals?.length && (
-              <div>
-                <div className="font-semibold text-gray-900">Training goals</div>
-                <div className="text-gray-600">{supplement.primary_goals.slice(0, 3).join(', ')}</div>
-              </div>
-            )}
-          </div>
+        <p className="text-sm text-gray-600 line-clamp-2 max-w-3xl">
+          {supplement.supplement_description}
+        </p>
+        {supplement.common_dosage && (
+          <p className="text-xs text-gray-500">Typical dose: {supplement.common_dosage}</p>
         )}
       </Stack>
 
       {/* Products Section */}
       <Stack gap={6}>
-        <h2 className="text-2xl font-semibold text-gray-900">Shop Stack Picks</h2>
 
         {/* Filter Panel */}
         <ProductFilterPanel
@@ -253,7 +241,7 @@ export default function SupplementPage({ params }: { params: { id: string } }) {
           />
         ) : (
           <>
-            <Grid cols={{ sm: 1, md: 2, lg: 3 }} gap={6}>
+            <Grid cols={{ sm: 2, md: 3, lg: 4 }} gap={4}>
               {displayedProducts.map((product) => (
                 <ProductCard key={product.product_id} product={product} />
               ))}

--- a/src/components/composite/Supplement/FeaturedCategories.tsx
+++ b/src/components/composite/Supplement/FeaturedCategories.tsx
@@ -1,63 +1,71 @@
 'use client';
 
 import Link from 'next/link';
-import { FiActivity, FiRefreshCw, FiZap } from 'react-icons/fi';
+import Image from 'next/image';
 import type { Supplement } from '@/types';
+import { formatPrice } from '@/lib/utils';
 
 export interface FeaturedCategoriesProps {
   supplements: Supplement[];
 }
 
+/**
+ * Amazon-style category shelves: each goal is a 2x2 grid of real product
+ * photos that link straight into supplement pages.
+ */
 export function FeaturedCategories({ supplements }: FeaturedCategoriesProps) {
   const featuredCategories = [
     {
       name: 'Protein & Mass',
-      description: 'Whey, casein, plant protein, and muscle-building staples',
-      supplements: supplements
-        .filter(s => ['Protein'].includes(s.category || ''))
-        .slice(0, 4),
-      icon: <FiActivity className="h-5 w-5" />
+      supplements: supplements.filter((s) => ['Protein'].includes(s.category || '')).slice(0, 4),
     },
     {
       name: 'Strength & Performance',
-      description: 'Creatine, pump, power, and pre-workout stack builders',
       supplements: supplements
-        .filter(s => ['Performance', 'Amino Acids'].includes(s.category || ''))
+        .filter((s) => ['Performance', 'Amino Acids'].includes(s.category || ''))
         .slice(0, 4),
-      icon: <FiZap className="h-5 w-5" />
     },
     {
       name: 'Recovery & Hydration',
-      description: 'Electrolytes, omega-3s, magnesium, and post-training support',
       supplements: supplements
-        .filter(s => ['Minerals', 'Omega & Fish Oil', 'Sleep & Relaxation'].includes(s.category || ''))
+        .filter((s) => ['Minerals', 'Omega & Fish Oil', 'Sleep & Relaxation'].includes(s.category || ''))
         .slice(0, 4),
-      icon: <FiRefreshCw className="h-5 w-5" />
-    }
+    },
   ];
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-16">
-      {featuredCategories.map((category, index) => (
-        <div
-          key={index}
-          className="rounded-lg border border-gray-100 bg-white p-6 text-gray-900 transition-colors duration-150 hover:border-gray-300"
-          style={{ animationDelay: `${index * 0.2}s` }}
-        >
-          <div className="mb-4 inline-flex h-10 w-10 items-center justify-center rounded bg-gray-100 text-gray-700">
-            {category.icon}
-          </div>
-          <h3 className="mb-2 font-serif text-2xl text-gray-900">{category.name}</h3>
-          <p className="mb-5 text-sm leading-6 text-gray-600">{category.description}</p>
-          <div className="space-y-1">
-            {category.supplements.slice(0, 3).map(supplement => (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+      {featuredCategories.map((category) => (
+        <div key={category.name} className="rounded border border-gray-200 bg-white p-4">
+          <h3 className="mb-3 text-base font-semibold text-gray-900">{category.name}</h3>
+          <div className="grid grid-cols-2 gap-2">
+            {category.supplements.map((supplement) => (
               <Link
                 key={supplement.supplement_id}
                 href={`/supplement/${supplement.supplement_id}`}
-                className="flex items-center justify-between rounded px-2 py-2 text-sm text-gray-700 transition-colors duration-150 hover:bg-gray-50 hover:text-gray-900"
+                className="group block"
               >
-                <span>{supplement.supplement_name}</span>
-                <span className="text-gray-400">View</span>
+                <div className="relative aspect-square overflow-hidden rounded border border-gray-100 bg-white">
+                  {supplement.image_url ? (
+                    <Image
+                      src={supplement.image_url}
+                      alt={supplement.supplement_name}
+                      fill
+                      className="object-contain p-2 transition-transform duration-200 group-hover:scale-[1.05]"
+                      sizes="(max-width: 768px) 40vw, 15vw"
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center text-xl font-semibold text-gray-300">
+                      {supplement.supplement_name.charAt(0)}
+                    </div>
+                  )}
+                </div>
+                <p className="mt-1 truncate text-xs text-gray-700 group-hover:underline">
+                  {supplement.supplement_name}
+                </p>
+                <p className="text-xs font-semibold text-gray-900">
+                  ${formatPrice(supplement.average_price ?? 24)}
+                </p>
               </Link>
             ))}
           </div>

--- a/src/components/composite/Supplement/SupplementCard.tsx
+++ b/src/components/composite/Supplement/SupplementCard.tsx
@@ -2,9 +2,7 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { FiArrowRight, FiCheckCircle } from 'react-icons/fi';
 import type { Supplement } from '@/types';
-import { Badge } from '@/components/ui';
 import { formatPrice } from '@/lib/utils';
 
 export interface SupplementCardProps {
@@ -12,71 +10,44 @@ export interface SupplementCardProps {
   index?: number;
 }
 
-export function SupplementCard({ supplement, index = 0 }: SupplementCardProps) {
-  const evidenceLabel = supplement.evidence_rating
-    ? `${supplement.evidence_rating.charAt(0).toUpperCase()}${supplement.evidence_rating.slice(1)} evidence`
-    : 'Verified category';
-
+/**
+ * Dense marketplace tile: real product photo first, minimal text —
+ * name, price, and option count, like an Amazon search result.
+ */
+export function SupplementCard({ supplement }: SupplementCardProps) {
   return (
     <Link href={`/supplement/${supplement.supplement_id}`} className="block h-full">
-      <div
-        className="group flex h-full flex-col overflow-hidden rounded-lg border border-gray-100 bg-white transition-colors duration-150 hover:border-gray-300 animate-fade-in"
-        style={{ animationDelay: `${index * 0.1}s` }}
-      >
-        <div className="relative flex h-44 items-center justify-center overflow-hidden border-b border-gray-100 bg-gray-50">
+      <div className="group flex h-full flex-col overflow-hidden rounded border border-gray-200 bg-white transition-all duration-150 hover:border-gray-300 hover:shadow-md">
+        <div className="relative aspect-square w-full bg-white">
           {supplement.image_url ? (
             <Image
               src={supplement.image_url}
               alt={supplement.supplement_name}
               fill
-              className="object-cover grayscale-[15%] transition-transform duration-300 group-hover:scale-[1.03]"
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              className="object-contain p-3 transition-transform duration-200 group-hover:scale-[1.04]"
+              sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 20vw"
             />
           ) : (
-            <div className="flex h-16 w-16 items-center justify-center rounded-full border border-gray-200 bg-white">
-              <span className="text-2xl font-semibold text-gray-900">
+            <div className="flex h-full items-center justify-center">
+              <span className="text-3xl font-semibold text-gray-300">
                 {supplement.supplement_name.charAt(0)}
               </span>
             </div>
           )}
-          <div className="absolute left-3 top-3">
-            <Badge variant="primary">{supplement.category || 'Supplement'}</Badge>
-          </div>
         </div>
 
-        <div className="flex flex-1 flex-col p-5">
-          <div className="mb-3 flex items-center gap-2 text-xs font-medium text-gray-500">
-            <FiCheckCircle className="h-3.5 w-3.5 text-green-600" />
-            <span>{evidenceLabel}</span>
-          </div>
-
-          <h3 className="mb-3 font-serif text-xl text-gray-900 line-clamp-2">
+        <div className="flex flex-1 flex-col border-t border-gray-100 p-3">
+          <h3 className="text-sm font-medium leading-5 text-gray-900 line-clamp-2 group-hover:underline">
             {supplement.supplement_name}
           </h3>
-          <p className="mb-5 text-sm leading-6 text-gray-600 line-clamp-3">
-            {supplement.supplement_description}
-          </p>
-
-          <div className="mt-auto space-y-4">
-            <div className="grid grid-cols-2 gap-3 border-y border-gray-100 py-3 text-xs">
-              <div>
-                <div className="font-semibold text-gray-900">
-                  {supplement.product_count ?? 24}
-                </div>
-                <div className="text-gray-500">products</div>
-              </div>
-              <div>
-                <div className="font-semibold text-gray-900">
-                  ${formatPrice(supplement.average_price ?? 24)}
-                </div>
-                <div className="text-gray-500">avg price</div>
-              </div>
-            </div>
-
-            <div className="flex items-center justify-between text-sm font-medium text-gray-900">
-              <span>Shop products</span>
-              <FiArrowRight className="h-4 w-4 transition-transform duration-150 group-hover:translate-x-1" />
-            </div>
+          <div className="mt-auto pt-2">
+            <span className="text-lg font-semibold text-gray-900">
+              ${formatPrice(supplement.average_price ?? 24)}
+            </span>
+            <p className="text-xs text-gray-500">
+              {supplement.product_count ?? 1} option{(supplement.product_count ?? 1) === 1 ? '' : 's'}
+              {supplement.category ? ` · ${supplement.category}` : ''}
+            </p>
           </div>
         </div>
       </div>

--- a/src/components/composite/Supplement/SupplementGrid.tsx
+++ b/src/components/composite/Supplement/SupplementGrid.tsx
@@ -9,7 +9,7 @@ export interface SupplementGridProps {
 
 export function SupplementGrid({ supplements }: SupplementGridProps) {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 sm:gap-4">
       {supplements.map((supplement, index) => (
         <SupplementCard
           key={supplement.supplement_id}

--- a/src/lib/catalog/supplement-catalog.ts
+++ b/src/lib/catalog/supplement-catalog.ts
@@ -2184,27 +2184,16 @@ function createCuratedProductsForSupplement(supplement: Supplement): Product[] {
   );
 }
 
-function categoryImage(category: string) {
-  const imageByCategory: Record<string, string> = {
-    Vitamins: 'https://images.unsplash.com/photo-1593095948071-474c5cc2989d?w=640&h=480&fit=crop',
-    Minerals: 'https://images.unsplash.com/photo-1607619056574-7b8d3ee536b2?w=640&h=480&fit=crop',
-    'Omega & Fish Oil': 'https://images.unsplash.com/photo-1535185384036-28bbc8035f28?w=640&h=480&fit=crop',
-    Protein: 'https://images.unsplash.com/photo-1517836357463-d25dfeac3438?w=640&h=480&fit=crop',
-    Performance: 'https://images.unsplash.com/photo-1517836357463-d25dfeac3438?w=640&h=480&fit=crop',
-    'Herbs & Adaptogens': 'https://images.unsplash.com/photo-1515586838455-8f8f940d6853?w=640&h=480&fit=crop',
-    'Brain & Focus': 'https://images.unsplash.com/photo-1559757175-5700dde675bc?w=640&h=480&fit=crop',
-    'Amino Acids': 'https://images.unsplash.com/photo-1579722820308-d74e571900a9?w=640&h=480&fit=crop',
-    'Sleep & Relaxation': 'https://images.unsplash.com/photo-1541781774459-bb2af2f05b55?w=640&h=480&fit=crop',
-    'Gut Health': 'https://images.unsplash.com/photo-1559757148-5c350d0d3c56?w=640&h=480&fit=crop',
-    Metabolic: 'https://images.unsplash.com/photo-1490645935967-10de6ba17061?w=640&h=480&fit=crop',
-    'Heart Health': 'https://images.unsplash.com/photo-1505751172876-fa1923c5c528?w=640&h=480&fit=crop',
-    Longevity: 'https://images.unsplash.com/photo-1559757148-5c350d0d3c56?w=640&h=480&fit=crop',
-    'Joint & Bone': 'https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?w=640&h=480&fit=crop',
-    Beauty: 'https://images.unsplash.com/photo-1522335789203-aabd1fc54bc9?w=640&h=480&fit=crop',
-    'Immune Support': 'https://images.unsplash.com/photo-1505751172876-fa1923c5c528?w=640&h=480&fit=crop',
-  };
-
-  return imageByCategory[category] ?? imageByCategory.Vitamins;
+/**
+ * Real merchant product photography — every catalog supplement has at least
+ * one curated product with a Shopify CDN image, so supplement tiles show an
+ * actual product instead of stock category imagery.
+ */
+function productImageForSupplementName(supplementName: string) {
+  const withImage = curatedSeedsForSupplementName(supplementName).find(
+    (product) => product.product_image
+  );
+  return withImage?.product_image ?? '';
 }
 
 export const supplementCatalog: Supplement[] = seeds.map((seed, index) => {
@@ -2214,7 +2203,7 @@ export const supplementCatalog: Supplement[] = seeds.map((seed, index) => {
     supplement_id: catalogIdForSeed(seed),
     supplement_name: seed.name,
     supplement_description: seed.description,
-    image_url: categoryImage(seed.category),
+    image_url: productImageForSupplementName(seed.name),
     category: seed.category,
     aliases: seed.aliases,
     evidence_rating: seed.evidence,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the stock-photo problem (including a literal cat photo on Sleep & Relaxation supplements) and reshapes the browsing experience into a product-first marketplace.

### Real product images everywhere
- Supplement tiles no longer use Unsplash category stock photos — the "Sleep & Relaxation" image was a cat sleeping under a duvet, and it appeared on Melatonin, Valerian, GABA, and every other sleep supplement.
- Every one of the 91 catalog supplements now shows the actual Shopify merchant product photo from its curated product (all verified on `cdn.shopify.com`), including in fallback product listings.

### Amazon-style density
- **Homepage:** removed the full-screen hero (also a stock gym photo), marketing copy blocks, and stats. It now opens with search, filters, and a product grid — 2–5 columns of image-led tiles.
- **Supplement tiles:** square product photo, name, price, option count. No more paragraph descriptions per tile.
- **Product cards:** square product image, brand, title, rating, price with per-serving cost, buy button. Removed the stat boxes, badge rows, and dosage sentences.
- **"Shop by Training Goal":** now 2×2 grids of real product photos per goal instead of text lists.
- **Supplement pages:** compressed the header to a two-line description and moved products up; product grid is now 4 columns.

### Verification
- All 91 supplements resolve a Shopify CDN product image (scripted check, 0 missing).
- `tsc`, lint, and production build pass; `/`, `/supplement/9001`, `/brands` return 200 and the Next image optimizer serves the Shopify CDN images.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f27bd-1375-77df-bd48-13ff1de1c1c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f27bd-1375-77df-bd48-13ff1de1c1c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

