### PR TITLE
Correctness & security fixes: social counts, checkout SSRF, responsive Grid

### DIFF
--- a/src/app/api/commerce/checkout/route.ts
+++ b/src/app/api/commerce/checkout/route.ts
@@ -3,10 +3,29 @@ import { createClient } from '@supabase/supabase-js';
 import type { Product } from '@/types';
 import { createFallbackPurchaseSession } from '@/lib/commerce/purchase-session';
 import { resolveShopifyPurchaseSession } from '@/lib/commerce/shopify-ucp-server';
+import { isAllowedMerchantHost } from '@/lib/catalog/supplement-catalog';
+
+/**
+ * Extracts a bare hostname from a raw store-domain string that may include a
+ * scheme or path (e.g. "https://cart.example.com/" -> "cart.example.com").
+ */
+function hostFromStoreDomain(storeDomain?: string | null): string | null {
+  if (!storeDomain) return null;
+  try {
+    const withScheme = storeDomain.includes('://') ? storeDomain : `https://${storeDomain}`;
+    return new URL(withScheme).hostname;
+  } catch {
+    return null;
+  }
+}
 
 function supabaseServer() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  // commerce_checkout_events has RLS enabled with no client-facing policies, so
+  // it can only be written with the service-role key. Fall back to the anon key
+  // only for environments where the service role is not configured (writes will
+  // then be denied by RLS, which is the safe failure mode).
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   if (!url || !key) return null;
   return createClient(url, key, {
     auth: {
@@ -50,7 +69,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'A product payload is required.' }, { status: 400 });
     }
 
-    const shouldAttemptUcp = Boolean(product.shopify_store_domain && product.shopify_variant_gid);
+    // UCP discovery makes outbound requests to the store domain. Since this
+    // route is unauthenticated and the client controls the payload, only
+    // attempt it for merchant hosts that are actually present in our catalog —
+    // otherwise this endpoint could be used to probe arbitrary hosts (SSRF).
+    const storeHost = hostFromStoreDomain(product.shopify_store_domain);
+    const shouldAttemptUcp = Boolean(
+      storeHost && product.shopify_variant_gid && isAllowedMerchantHost(storeHost)
+    );
     const session = shouldAttemptUcp
       ? await resolveShopifyPurchaseSession(product, quantity)
       : createFallbackPurchaseSession(product, quantity);

--- a/src/app/api/commerce/product-status/route.ts
+++ b/src/app/api/commerce/product-status/route.ts
@@ -1,22 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { fetchShopifyProductJson } from '@/lib/catalog/shopify-catalog-verifier';
 import { getShopifyVariantNumericId } from '@/lib/commerce/shopify-ucp';
-import { allCuratedProductSeeds } from '@/lib/catalog/supplement-catalog';
-
-function normalizeHost(host: string) {
-  return host.toLowerCase().replace(/^www\./, '');
-}
-
-/**
- * Only merchant domains present in the catalog may be fetched; this endpoint
- * is unauthenticated and must not act as an open proxy (SSRF).
- */
-const ALLOWED_MERCHANT_HOSTS = new Set(
-  allCuratedProductSeeds
-    .map((seed) => seed.shopify_store_domain)
-    .filter((domain): domain is string => Boolean(domain))
-    .map(normalizeHost)
-);
+import { isAllowedMerchantHost } from '@/lib/catalog/supplement-catalog';
 
 /** product.js variant prices are integer cents on most stores, but some themes return dollar strings. */
 function normalizePrice(value: number | string | undefined) {
@@ -58,7 +43,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid productUrl.' }, { status: 400 });
   }
 
-  if (parsedUrl.protocol !== 'https:' || !ALLOWED_MERCHANT_HOSTS.has(normalizeHost(parsedUrl.hostname))) {
+  if (parsedUrl.protocol !== 'https:' || !isAllowedMerchantHost(parsedUrl.hostname)) {
     return NextResponse.json({ error: 'Merchant domain is not allowed.' }, { status: 400 });
   }
 

--- a/src/components/ui/layout/Grid.tsx
+++ b/src/components/ui/layout/Grid.tsx
@@ -17,6 +17,9 @@ const gapMap: Record<SpacingValue, string> = {
   16: 'gap-16',
 };
 
+// Full, static class strings per breakpoint. Tailwind's JIT only emits classes
+// it can find as complete literals in source — building them at runtime (e.g.
+// `md:${colsMap[md]}`) means the responsive variants are never generated.
 const colsMap: Record<ColumnsValue, string> = {
   1: 'grid-cols-1',
   2: 'grid-cols-2',
@@ -25,6 +28,36 @@ const colsMap: Record<ColumnsValue, string> = {
   5: 'grid-cols-5',
   6: 'grid-cols-6',
   12: 'grid-cols-12',
+};
+
+const mdColsMap: Record<ColumnsValue, string> = {
+  1: 'md:grid-cols-1',
+  2: 'md:grid-cols-2',
+  3: 'md:grid-cols-3',
+  4: 'md:grid-cols-4',
+  5: 'md:grid-cols-5',
+  6: 'md:grid-cols-6',
+  12: 'md:grid-cols-12',
+};
+
+const lgColsMap: Record<ColumnsValue, string> = {
+  1: 'lg:grid-cols-1',
+  2: 'lg:grid-cols-2',
+  3: 'lg:grid-cols-3',
+  4: 'lg:grid-cols-4',
+  5: 'lg:grid-cols-5',
+  6: 'lg:grid-cols-6',
+  12: 'lg:grid-cols-12',
+};
+
+const xlColsMap: Record<ColumnsValue, string> = {
+  1: 'xl:grid-cols-1',
+  2: 'xl:grid-cols-2',
+  3: 'xl:grid-cols-3',
+  4: 'xl:grid-cols-4',
+  5: 'xl:grid-cols-5',
+  6: 'xl:grid-cols-6',
+  12: 'xl:grid-cols-12',
 };
 
 export interface GridProps extends HTMLAttributes<HTMLDivElement> {
@@ -60,12 +93,14 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
     if (typeof cols === 'number') {
       colClasses = colsMap[cols];
     } else {
+      // `sm` is the mobile-first base (no breakpoint prefix); md/lg/xl layer on
+      // top at their breakpoints.
       const { sm = 1, md, lg, xl } = cols;
       colClasses = cn(
         colsMap[sm],
-        md && `md:${colsMap[md]}`,
-        lg && `lg:${colsMap[lg]}`,
-        xl && `xl:${colsMap[xl]}`
+        md && mdColsMap[md],
+        lg && lgColsMap[lg],
+        xl && xlColsMap[xl]
       );
     }
 

--- a/src/hooks/useStackLikes.ts
+++ b/src/hooks/useStackLikes.ts
@@ -82,7 +82,6 @@ export function useStackLikes(stackId?: string): UseStackLikesResult {
 
     try {
       if (isLiked) {
-        // Unlike
         const { error } = await supabase
           .from('stack_likes')
           .delete()
@@ -93,14 +92,7 @@ export function useStackLikes(stackId?: string): UseStackLikesResult {
 
         setIsLiked(false);
         setLikeCount(prev => Math.max(0, prev - 1));
-
-        // Update stack like_count
-        await supabase
-          .from('stacks')
-          .update({ like_count: Math.max(0, likeCount - 1) })
-          .eq('stack_id', stackId);
       } else {
-        // Like
         const { error } = await supabase
           .from('stack_likes')
           .insert({
@@ -112,12 +104,19 @@ export function useStackLikes(stackId?: string): UseStackLikesResult {
 
         setIsLiked(true);
         setLikeCount(prev => prev + 1);
+      }
 
-        // Update stack like_count
-        await supabase
-          .from('stacks')
-          .update({ like_count: likeCount + 1 })
-          .eq('stack_id', stackId);
+      // stacks.like_count is maintained by the trigger_update_like_counts
+      // database trigger; re-read the authoritative value instead of writing
+      // it a second time here (a double-write would drift the count).
+      const { data: stack } = await supabase
+        .from('stacks')
+        .select('like_count')
+        .eq('stack_id', stackId)
+        .single();
+
+      if (typeof stack?.like_count === 'number') {
+        setLikeCount(stack.like_count);
       }
     } catch (err) {
       console.error('Error toggling like:', err);
@@ -125,7 +124,7 @@ export function useStackLikes(stackId?: string): UseStackLikesResult {
     } finally {
       setIsLoading(false);
     }
-  }, [user, stackId, profileId, isLiked, likeCount]);
+  }, [user, stackId, profileId, isLiked]);
 
   // Fetch all stacks the user has liked
   const fetchLikedStacks = useCallback(async () => {

--- a/src/hooks/useUserFollows.ts
+++ b/src/hooks/useUserFollows.ts
@@ -92,7 +92,6 @@ export function useUserFollows(targetProfileId?: string): UseUserFollowsResult {
 
     try {
       if (isFollowing) {
-        // Unfollow
         const { error } = await supabase
           .from('user_follows')
           .delete()
@@ -103,26 +102,7 @@ export function useUserFollows(targetProfileId?: string): UseUserFollowsResult {
 
         setIsFollowing(false);
         setFollowerCount(prev => Math.max(0, prev - 1));
-
-        // Update target's follower count
-        await supabase
-          .from('user_profiles')
-          .update({ follower_count: Math.max(0, followerCount - 1) })
-          .eq('profile_id', targetProfileId);
-
-        // Update my following count
-        const { data: myProfile } = await supabase
-          .from('user_profiles')
-          .select('following_count')
-          .eq('profile_id', myProfileId)
-          .single();
-
-        await supabase
-          .from('user_profiles')
-          .update({ following_count: Math.max(0, (myProfile?.following_count || 1) - 1) })
-          .eq('profile_id', myProfileId);
       } else {
-        // Follow
         const { error } = await supabase
           .from('user_follows')
           .insert({
@@ -134,24 +114,20 @@ export function useUserFollows(targetProfileId?: string): UseUserFollowsResult {
 
         setIsFollowing(true);
         setFollowerCount(prev => prev + 1);
+      }
 
-        // Update target's follower count
-        await supabase
-          .from('user_profiles')
-          .update({ follower_count: followerCount + 1 })
-          .eq('profile_id', targetProfileId);
+      // follower_count / following_count are maintained by the
+      // trigger_update_follower_counts database trigger. Re-read the target's
+      // authoritative follower count rather than writing it again here — the
+      // previous manual updates double-counted and drifted over time.
+      const { data: profile } = await supabase
+        .from('user_profiles')
+        .select('follower_count')
+        .eq('profile_id', targetProfileId)
+        .single();
 
-        // Update my following count
-        const { data: myProfile } = await supabase
-          .from('user_profiles')
-          .select('following_count')
-          .eq('profile_id', myProfileId)
-          .single();
-
-        await supabase
-          .from('user_profiles')
-          .update({ following_count: (myProfile?.following_count || 0) + 1 })
-          .eq('profile_id', myProfileId);
+      if (typeof profile?.follower_count === 'number') {
+        setFollowerCount(profile.follower_count);
       }
     } catch (err) {
       console.error('Error toggling follow:', err);
@@ -159,7 +135,7 @@ export function useUserFollows(targetProfileId?: string): UseUserFollowsResult {
     } finally {
       setIsLoading(false);
     }
-  }, [user, targetProfileId, myProfileId, isFollowing, followerCount]);
+  }, [user, targetProfileId, myProfileId, isFollowing]);
 
   // Fetch followers for a profile
   const fetchFollowers = useCallback(async (profileId: string) => {

--- a/src/lib/catalog/supplement-catalog.ts
+++ b/src/lib/catalog/supplement-catalog.ts
@@ -2452,3 +2452,26 @@ export function findCatalogProductById(productId: string) {
 
   return createCatalogProductsForSupplement(supplement).find((product) => product.product_id === productId) ?? null;
 }
+
+function normalizeMerchantHost(host: string) {
+  return host.toLowerCase().replace(/^www\./, '');
+}
+
+/**
+ * The set of merchant hosts that appear in the curated catalog. Unauthenticated
+ * server routes (checkout, product-status) fetch merchant endpoints, so they
+ * must restrict outbound requests to these known hosts to avoid acting as an
+ * open proxy (SSRF).
+ */
+const ALLOWED_MERCHANT_HOSTS = new Set(
+  allCuratedProductSeeds
+    .map((seed) => seed.shopify_store_domain)
+    .filter((domain): domain is string => Boolean(domain))
+    .map(normalizeMerchantHost)
+);
+
+/** True when `host` (a bare hostname) is a merchant present in the catalog. */
+export function isAllowedMerchantHost(host?: string | null): boolean {
+  if (!host) return false;
+  return ALLOWED_MERCHANT_HOSTS.has(normalizeMerchantHost(host));
+}

--- a/src/scripts/addCommerceCheckoutEventsRls.sql
+++ b/src/scripts/addCommerceCheckoutEventsRls.sql
@@ -1,0 +1,14 @@
+-- Locks down commerce_checkout_events. This table is written by the
+-- /api/commerce/checkout server route to record purchase intent. It has no
+-- reason to be readable or writable by end-user (anon/authenticated) clients.
+--
+-- Enabling RLS with no permissive policies denies all access via the anon and
+-- authenticated keys, while the service_role key used by the server route
+-- bypasses RLS. Run after addCommerceSessionTracking.sql.
+
+ALTER TABLE commerce_checkout_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE commerce_checkout_events FORCE ROW LEVEL SECURITY;
+
+-- No SELECT/INSERT/UPDATE/DELETE policies are defined on purpose: with RLS
+-- enabled and no policies, anon/authenticated roles get zero rows and cannot
+-- write. Only the service_role (server-side) key can read/write this table.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
First remediation PR from the platform audit — the correctness and security items.

## 1. Double-counted follower / like counts (data correctness)

`stacks.like_count` and `user_profiles.follower_count`/`following_count` are already maintained by database triggers (`trigger_update_like_counts`, `trigger_update_follower_counts`). The hooks were *also* writing these columns manually from stale React closure values, so every like/follow toggled the count **twice** and drifted over time (and could go negative or double-decrement on races).

- `useStackLikes.ts` / `useUserFollows.ts`: removed the manual `update({ like_count })` / `update({ follower_count, following_count })` writes. After the insert/delete, we now re-read the authoritative value the trigger produced and set local state from it. Also dropped the now-unused `likeCount` / `followerCount` from the `useCallback` deps.

## 2. Checkout API SSRF (security)

`POST /api/commerce/checkout` is unauthenticated and the client controls the entire `product` payload. It attempted Shopify UCP discovery (outbound `fetch` to `/.well-known/ucp` + JSON-RPC) against any `shopify_store_domain` supplied, which could be abused to probe arbitrary hosts.

- Added a shared `isAllowedMerchantHost()` helper in `supplement-catalog.ts`, derived from the merchant domains in the curated catalog.
- The checkout route now only attempts UCP for a store host that is present in the catalog; anything else falls back to the safe deep-link session.
- Refactored `product-status/route.ts` to use the same shared helper, removing its duplicate inline allowlist (the audit flagged this duplication).

## 3. `commerce_checkout_events` lockdown (security)

This table had no RLS while every other table does, and the route used the anon key — so the event log was world-writable.

- New migration `src/scripts/addCommerceCheckoutEventsRls.sql` enables (and forces) RLS with **no** client-facing policies, so only the service-role server key can read/write it.
- The checkout route now prefers `SUPABASE_SERVICE_ROLE_KEY` (falling back to anon, where writes are then safely denied by RLS).

> Note: the RLS migration must be applied to the Supabase database, and `SUPABASE_SERVICE_ROLE_KEY` should be set in the deployment environment, for checkout-event logging to keep working. Logging is best-effort (failures are swallowed) so checkout itself is unaffected if it isn't.

## 4. Responsive `Grid` columns silently not rendering (UI correctness)

`Grid` built responsive classes with runtime template literals (`md:${colsMap[md]}`), which Tailwind's JIT compiler cannot detect, so `md:`/`lg:`/`xl:` column counts were never generated (used on the product detail page). Replaced with static per-breakpoint class maps so the strings are statically analyzable. `sm` remains the unprefixed mobile-first base to preserve existing behavior.

## Validation
- `npx tsc --noEmit` clean
- `npm run lint` clean (only pre-existing warnings, none in changed files)
- `npm run build` succeeds
- `npm run check:catalog` passes (`95 supplements, 161 curated products, 0 failures`)

Scoped intentionally to correctness/security; the larger de-duplication, schema-reconciliation, and data-access-layer items from the audit are follow-up PRs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f27bd-1375-77df-bd48-13ff1de1c1c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f27bd-1375-77df-bd48-13ff1de1c1c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

