### PR TITLE
SuppStack Premium: subscription tier with RevenueCat entitlements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,13 @@ SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
 # Optional: Admin token for seeding API (production only)
 # Generate with: openssl rand -base64 32
 ADMIN_SEED_TOKEN=your_admin_token
+
+# Premium subscriptions (RevenueCat) — see PREMIUM_BILLING.md
+# Shared secret set as the Authorization header on the RevenueCat webhook
+# (Integrations > Webhooks). Generate with: openssl rand -base64 32
+REVENUECAT_WEBHOOK_AUTH_TOKEN=your_webhook_auth_token
+# RevenueCat Web Billing purchase link for the premium plan (without the
+# trailing app_user_id segment), e.g. https://pay.rev.cat/abcdef123
+NEXT_PUBLIC_PREMIUM_CHECKOUT_URL=
+# Optional: RevenueCat customer portal link for managing a subscription
+NEXT_PUBLIC_PREMIUM_MANAGE_URL=

--- a/PREMIUM_BILLING.md
+++ b/PREMIUM_BILLING.md
@@ -1,0 +1,72 @@
+# Premium subscriptions (RevenueCat)
+
+SuppStack Premium gates the personal analytics layer (wellness trends,
+efficacy insights, restock reminders, cost analytics) behind a subscription.
+The marketplace, wiki, stacks, and daily logging stay free.
+
+## Architecture
+
+RevenueCat is the billing system of record; the app never talks to it on the
+read path.
+
+```
+Web:  /premium → RevenueCat Web Billing purchase link (Stripe under the hood)
+iOS:  @revenuecat/purchases-capacitor → Apple IAP (see branch cursor/ios-app-store-c1c7)
+                       │
+                       ▼
+      RevenueCat webhook → POST /api/billing/revenuecat
+                       │     (auth: REVENUECAT_WEBHOOK_AUTH_TOKEN,
+                       │      writes with SUPABASE_SERVICE_ROLE_KEY)
+                       ▼
+      user_entitlements table (migration 0005, RLS: user reads own row)
+                       │
+                       ▼
+      usePremium() hook → <PremiumGate> around premium features
+```
+
+Key properties:
+
+- **One entitlement across platforms.** Clients identify to RevenueCat with
+  the Supabase user id as `app_user_id`, so a web subscription unlocks the
+  iOS app and vice versa.
+- **Server-authoritative.** Clients can only *read* their entitlement row;
+  all writes go through the webhook with the service-role key. Nobody can
+  grant themselves premium from the browser.
+- **Degrades gracefully.** Until the env vars are configured, the pricing
+  page shows "launching soon" and the webhook returns 503 — nothing breaks.
+
+## Setup checklist
+
+1. **Create a RevenueCat project** (app.revenuecat.com) with an entitlement
+   named `premium` — the identifier the code expects
+   (`PREMIUM_ENTITLEMENT` in `src/lib/billing/entitlements.ts`).
+2. **Web Billing:** connect Stripe, create a `premium_monthly` product at
+   $4.99/mo, attach it to the `premium` entitlement, and create a purchase
+   link. Put the link (without the trailing app-user segment) in
+   `NEXT_PUBLIC_PREMIUM_CHECKOUT_URL`. The app appends `/<supabase-user-id>`
+   so purchases attribute automatically.
+3. **Webhook:** Integrations → Webhooks → URL
+   `https://<your-domain>/api/billing/revenuecat`, Authorization header set
+   to the value you generate for `REVENUECAT_WEBHOOK_AUTH_TOKEN`
+   (`openssl rand -base64 32`).
+4. **Env vars on Vercel:** `REVENUECAT_WEBHOOK_AUTH_TOKEN`,
+   `NEXT_PUBLIC_PREMIUM_CHECKOUT_URL`, optionally
+   `NEXT_PUBLIC_PREMIUM_MANAGE_URL` (customer portal link), plus the existing
+   `SUPABASE_SERVICE_ROLE_KEY`.
+5. **Database:** apply `supabase/migrations/20260101000005_billing.sql`
+   (`supabase db push`).
+6. **iOS (when the Capacitor branch ships):** create the subscription in App
+   Store Connect, add `@revenuecat/purchases-capacitor`, call
+   `Purchases.configure({ apiKey, appUserID: supabaseUserId })` after login,
+   and present the paywall with the same `premium` entitlement. Apple takes
+   15–30% of IAP vs ~3% on web, so web remains the primary purchase surface.
+
+## Testing
+
+- RevenueCat's webhook "send test event" should return
+  `{ received: true, ignored: "TEST" }`.
+- A sandbox purchase fires `INITIAL_PURCHASE`; verify a row appears in
+  `user_entitlements` with `status = 'active'` and the pricing page flips to
+  "You're a Premium member".
+- Cancelling in sandbox fires `CANCELLATION` (status `cancelled`, access
+  retained until `current_period_end`) and later `EXPIRATION` (locked).

--- a/src/app/api/billing/revenuecat/route.ts
+++ b/src/app/api/billing/revenuecat/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { PREMIUM_ENTITLEMENT, type EntitlementStatus } from '@/lib/billing/entitlements';
+
+/**
+ * RevenueCat webhook receiver.
+ *
+ * RevenueCat is the billing system of record; this route mirrors subscription
+ * state into `user_entitlements` so the app can check premium status with a
+ * plain RLS-protected Supabase query. Configure in the RevenueCat dashboard:
+ *   Integrations → Webhooks → URL: https://<host>/api/billing/revenuecat
+ *   Authorization header: the value of REVENUECAT_WEBHOOK_AUTH_TOKEN.
+ *
+ * Clients identify to RevenueCat with the Supabase user id as the
+ * app_user_id, which is how events map back to a row here.
+ */
+
+interface RevenueCatEvent {
+  type: string;
+  app_user_id?: string;
+  original_app_user_id?: string;
+  entitlement_ids?: string[];
+  product_id?: string;
+  store?: string;
+  environment?: string;
+  period_type?: string;
+  expiration_at_ms?: number;
+  cancel_reason?: string;
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function statusForEventType(type: string, periodType?: string): EntitlementStatus | null {
+  switch (type) {
+    case 'INITIAL_PURCHASE':
+    case 'RENEWAL':
+    case 'UNCANCELLATION':
+    case 'PRODUCT_CHANGE':
+      return periodType === 'TRIAL' ? 'trialing' : 'active';
+    case 'CANCELLATION':
+      return 'cancelled';
+    case 'BILLING_ISSUE':
+      return 'billing_issue';
+    case 'EXPIRATION':
+    case 'SUBSCRIPTION_PAUSED':
+      return 'expired';
+    default:
+      // TEST, TRANSFER, NON_RENEWING_PURCHASE, etc. — acknowledged, not mapped.
+      return null;
+  }
+}
+
+function normalizeStore(store?: string): string {
+  switch ((store || '').toUpperCase()) {
+    case 'APP_STORE':
+      return 'app_store';
+    case 'PLAY_STORE':
+      return 'play_store';
+    case 'STRIPE':
+      return 'stripe';
+    case 'RC_BILLING':
+      return 'rc_billing';
+    case 'PROMOTIONAL':
+      return 'promotional';
+    default:
+      return 'unknown';
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const expectedAuth = process.env.REVENUECAT_WEBHOOK_AUTH_TOKEN;
+  if (!expectedAuth) {
+    return NextResponse.json(
+      { error: 'Billing webhook is not configured.' },
+      { status: 503 }
+    );
+  }
+
+  const authHeader = request.headers.get('authorization') || '';
+  // RevenueCat sends the configured value verbatim (commonly "Bearer <token>").
+  if (authHeader !== expectedAuth && authHeader !== `Bearer ${expectedAuth}`) {
+    return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+  }
+
+  let event: RevenueCatEvent | undefined;
+  try {
+    const body = await request.json();
+    event = body?.event as RevenueCatEvent | undefined;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON payload.' }, { status: 400 });
+  }
+  if (!event?.type) {
+    return NextResponse.json({ error: 'Missing event payload.' }, { status: 400 });
+  }
+
+  const status = statusForEventType(event.type, event.period_type);
+  if (!status) {
+    // Event types we don't track (e.g. TEST pings) are acknowledged so
+    // RevenueCat doesn't retry them.
+    return NextResponse.json({ received: true, ignored: event.type });
+  }
+
+  const appUserId = event.app_user_id || event.original_app_user_id || '';
+  if (!UUID_PATTERN.test(appUserId)) {
+    // Anonymous RevenueCat ids ($RCAnonymousID:...) can't be mapped to a
+    // Supabase user. Acknowledge to avoid retry loops; the state will sync
+    // once the client logs in and RevenueCat aliases the id.
+    return NextResponse.json({ received: true, ignored: 'unmapped app_user_id' });
+  }
+
+  // Only checked once the event actually requires a write, so TEST pings and
+  // unmapped events succeed even before storage credentials are configured.
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    return NextResponse.json(
+      { error: 'Billing storage is not configured.' },
+      { status: 503 }
+    );
+  }
+
+  const entitlements = event.entitlement_ids?.length
+    ? event.entitlement_ids
+    : [PREMIUM_ENTITLEMENT];
+
+  const supabase = createClient(url, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  const rows = entitlements.map((entitlement) => ({
+    user_id: appUserId,
+    entitlement,
+    status,
+    store: normalizeStore(event!.store),
+    product_id: event!.product_id || null,
+    rc_app_user_id: appUserId,
+    current_period_end: event!.expiration_at_ms
+      ? new Date(event!.expiration_at_ms).toISOString()
+      : null,
+    will_renew: status === 'active' || status === 'trialing',
+    metadata: {
+      event_type: event!.type,
+      period_type: event!.period_type,
+      environment: event!.environment,
+      cancel_reason: event!.cancel_reason,
+    },
+  }));
+
+  const { error } = await supabase
+    .from('user_entitlements')
+    .upsert(rows, { onConflict: 'user_id,entitlement' });
+
+  if (error) {
+    // Non-2xx makes RevenueCat retry with backoff, which is what we want for
+    // transient database failures.
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -13,6 +13,7 @@ export default function Footer() {
           </div>
           
           <div className="flex items-center space-x-6 text-sm">
+            <a href="/premium" className="hover:text-orange-600 transition-colors duration-200">Premium</a>
             <a href="#" className="hover:text-orange-600 transition-colors duration-200">Privacy</a>
             <a href="#" className="hover:text-orange-600 transition-colors duration-200">Terms</a>
             <a href="#" className="hover:text-orange-600 transition-colors duration-200">Support</a>

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -43,6 +43,12 @@ export default function Header() {
             >
               Brands
             </Link>
+            <Link
+              href="/premium"
+              className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors"
+            >
+              Premium
+            </Link>
             {user && (
               <Link
                 href="/profile"

--- a/src/app/premium/page.tsx
+++ b/src/app/premium/page.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import Link from 'next/link';
+import { FiCheck, FiArrowRight } from 'react-icons/fi';
+import { useAuth } from '@/app/context/AuthContext';
+import { usePremium } from '@/hooks/usePremium';
+import {
+  PREMIUM_FEATURES,
+  PREMIUM_PRICE_LABEL,
+  premiumCheckoutUrl,
+} from '@/lib/billing/entitlements';
+import { Card, Badge, Spinner } from '@/components/ui';
+
+const FREE_FEATURES = [
+  'Browse and compare every supplement and product',
+  'Verified merchant checkout',
+  'Build and share stacks',
+  'Daily supplement logging and journal',
+];
+
+export default function PremiumPage() {
+  const { user, loading: authLoading, loginWithGoogle } = useAuth();
+  const { isPremium, entitlement, loading: premiumLoading } = usePremium();
+
+  const checkoutUrl = user ? premiumCheckoutUrl(user.id) : null;
+  const manageUrl = process.env.NEXT_PUBLIC_PREMIUM_MANAGE_URL;
+  const loading = authLoading || premiumLoading;
+
+  return (
+    <div className="container-custom py-12">
+      <div className="mx-auto max-w-3xl text-center">
+        <h1 className="text-3xl font-serif text-gray-900">SuppStack Premium</h1>
+        <p className="mx-auto mt-3 max-w-xl text-gray-600">
+          The marketplace and knowledge base stay free. Premium adds the
+          personal layer: trends, insights, and reminders built from your own
+          logs.
+        </p>
+      </div>
+
+      <div className="mx-auto mt-10 grid max-w-3xl grid-cols-1 gap-6 md:grid-cols-2">
+        {/* Free tier */}
+        <Card padding="lg">
+          <h2 className="text-lg font-medium text-gray-900">Free</h2>
+          <p className="mt-1 text-sm text-gray-500">Everything you need to shop smart.</p>
+          <p className="mt-4 text-2xl font-serif text-gray-900">$0</p>
+          <ul className="mt-6 space-y-3">
+            {FREE_FEATURES.map((feature) => (
+              <li key={feature} className="flex items-start gap-2.5 text-sm text-gray-700">
+                <FiCheck size={16} className="mt-0.5 shrink-0 text-gray-400" />
+                {feature}
+              </li>
+            ))}
+          </ul>
+        </Card>
+
+        {/* Premium tier */}
+        <Card padding="lg" className="border-gray-900">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-medium text-gray-900">Premium</h2>
+            <Badge variant="default">Insights</Badge>
+          </div>
+          <p className="mt-1 text-sm text-gray-500">Understand what actually works for you.</p>
+          <p className="mt-4 text-2xl font-serif text-gray-900">
+            {PREMIUM_PRICE_LABEL.split('/')[0]}
+            <span className="text-sm text-gray-500">/month</span>
+          </p>
+          <ul className="mt-6 space-y-3">
+            {PREMIUM_FEATURES.map((feature) => (
+              <li key={feature.name} className="flex items-start gap-2.5 text-sm">
+                <FiCheck size={16} className="mt-0.5 shrink-0 text-gray-900" />
+                <span>
+                  <span className="font-medium text-gray-900">{feature.name}.</span>{' '}
+                  <span className="text-gray-600">{feature.description}</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-8">
+            {loading ? (
+              <div className="flex justify-center py-2">
+                <Spinner size="md" />
+              </div>
+            ) : isPremium ? (
+              <div className="space-y-2 text-center">
+                <p className="text-sm font-medium text-gray-900">
+                  You&apos;re a Premium member
+                </p>
+                {entitlement?.current_period_end && (
+                  <p className="text-xs text-gray-500">
+                    {entitlement.will_renew ? 'Renews' : 'Access until'}{' '}
+                    {new Date(entitlement.current_period_end).toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })}
+                  </p>
+                )}
+                {manageUrl && (
+                  <a
+                    href={manageUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-block text-sm text-gray-600 underline underline-offset-4 hover:text-gray-900"
+                  >
+                    Manage subscription
+                  </a>
+                )}
+              </div>
+            ) : !user ? (
+              <button
+                onClick={() => loginWithGoogle()}
+                className="inline-flex w-full items-center justify-center gap-2 rounded bg-gray-900 px-5 py-3 text-sm font-medium text-white transition-colors duration-150 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2"
+              >
+                Sign in to upgrade
+                <FiArrowRight size={16} />
+              </button>
+            ) : checkoutUrl ? (
+              <a
+                href={checkoutUrl}
+                className="inline-flex w-full items-center justify-center gap-2 rounded bg-gray-900 px-5 py-3 text-sm font-medium text-white transition-colors duration-150 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2"
+              >
+                Upgrade to Premium
+                <FiArrowRight size={16} />
+              </a>
+            ) : (
+              <div className="rounded border border-gray-200 bg-gray-50 px-4 py-3 text-center text-sm text-gray-500">
+                Subscriptions are launching soon.
+              </div>
+            )}
+          </div>
+        </Card>
+      </div>
+
+      <p className="mx-auto mt-8 max-w-xl text-center text-xs text-gray-400">
+        Cancel anytime. Your logging history is never paywalled — Premium only
+        gates the analytics built on top of it.{' '}
+        <Link href="/terms" className="underline underline-offset-2 hover:text-gray-600">
+          Terms
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -46,6 +46,7 @@ import {
   EfficacyInsights,
   RestockReminders,
 } from '@/components/composite/Tracking';
+import { PremiumGate } from '@/components/composite/Billing';
 import { FiActivity } from 'react-icons/fi';
 
 type TabType = 'collection' | 'insights' | 'journal' | 'stacks' | 'profile';
@@ -443,10 +444,25 @@ export default function Profile() {
             </div>
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <WellnessTrends />
+              <PremiumGate
+                feature="Wellness trends"
+                description="Charts of energy, sleep, and mood over time, built from your daily logs."
+              >
+                <WellnessTrends />
+              </PremiumGate>
               <div className="space-y-6">
-                <EfficacyInsights />
-                <RestockReminders />
+                <PremiumGate
+                  feature="Efficacy insights"
+                  description="See which supplements correlate with how you actually feel."
+                >
+                  <EfficacyInsights />
+                </PremiumGate>
+                <PremiumGate
+                  feature="Restock reminders"
+                  description="Know when each container runs out based on your logging pace."
+                >
+                  <RestockReminders />
+                </PremiumGate>
               </div>
             </div>
           </section>

--- a/src/components/composite/Billing/PremiumGate.tsx
+++ b/src/components/composite/Billing/PremiumGate.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import { FiLock } from 'react-icons/fi';
+import { usePremium } from '@/hooks/usePremium';
+import { PREMIUM_PRICE_LABEL } from '@/lib/billing/entitlements';
+import { Card, Skeleton } from '@/components/ui';
+
+export interface PremiumGateProps {
+  /** Feature name shown in the upsell card (e.g. "Wellness trends"). */
+  feature: string;
+  /** One-line description of what the member gets. */
+  description?: string;
+  children: ReactNode;
+}
+
+/**
+ * Wraps a premium feature. Members see the feature; everyone else sees an
+ * upsell card that links to the pricing page. While entitlement status loads,
+ * a skeleton avoids flashing the paywall at paying members.
+ */
+export function PremiumGate({ feature, description, children }: PremiumGateProps) {
+  const { isPremium, loading } = usePremium();
+
+  if (loading) {
+    return (
+      <Card padding="md">
+        <Skeleton height={16} width={160} className="mb-3" />
+        <Skeleton height={12} className="mb-2" />
+        <Skeleton height={12} className="w-3/4" />
+      </Card>
+    );
+  }
+
+  if (isPremium) return <>{children}</>;
+
+  return (
+    <Card padding="md" className="text-center">
+      <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-gray-100">
+        <FiLock size={18} className="text-gray-500" />
+      </div>
+      <h3 className="text-base font-medium text-gray-900">{feature}</h3>
+      <p className="mx-auto mt-1 max-w-sm text-sm text-gray-500">
+        {description || 'This feature is part of SuppStack Premium.'}
+      </p>
+      <Link
+        href="/premium"
+        className="mt-4 inline-flex items-center justify-center rounded bg-gray-900 px-5 py-2.5 text-sm font-medium text-white transition-colors duration-150 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2"
+      >
+        Upgrade — {PREMIUM_PRICE_LABEL}
+      </Link>
+    </Card>
+  );
+}
+
+export default PremiumGate;

--- a/src/components/composite/Billing/index.ts
+++ b/src/components/composite/Billing/index.ts
@@ -1,0 +1,2 @@
+export { PremiumGate } from './PremiumGate';
+export type { PremiumGateProps } from './PremiumGate';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -18,6 +18,10 @@ export type { UserPreferences } from './useLocalStorage';
 export { useReviews } from './useReviews';
 export type { UseReviewsOptions, UseReviewsResult, ReviewSortBy } from './useReviews';
 
+// Billing
+export { usePremium } from './usePremium';
+export type { UsePremiumResult } from './usePremium';
+
 // Tracking & Logging Hooks
 export { useSupplementLogs } from './useSupplementLogs';
 export type { UseSupplementLogsOptions, UseSupplementLogsResult } from './useSupplementLogs';

--- a/src/hooks/usePremium.ts
+++ b/src/hooks/usePremium.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { supabase } from '@/app/supabase';
+import { useAuth } from '@/app/context/AuthContext';
+import {
+  PREMIUM_ENTITLEMENT,
+  isEntitlementActive,
+  type UserEntitlement,
+} from '@/lib/billing/entitlements';
+
+export interface UsePremiumResult {
+  /** Whether the signed-in user currently has an active premium entitlement. */
+  isPremium: boolean;
+  /** The raw entitlement row (for period end / store in account settings). */
+  entitlement: UserEntitlement | null;
+  loading: boolean;
+  refetch: () => Promise<void>;
+}
+
+/**
+ * Premium subscription status for the current user.
+ *
+ * Reads the RLS-protected `user_entitlements` mirror that the RevenueCat
+ * webhook keeps in sync — no billing SDK involved on the read path. Signed-out
+ * users are never premium.
+ */
+export function usePremium(): UsePremiumResult {
+  const { user, loading: authLoading } = useAuth();
+  const [entitlement, setEntitlement] = useState<UserEntitlement | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchEntitlement = useCallback(async () => {
+    if (!user) {
+      setEntitlement(null);
+      setLoading(false);
+      return;
+    }
+    try {
+      const { data } = await supabase
+        .from('user_entitlements')
+        .select(
+          'entitlement_id, user_id, entitlement, status, store, product_id, current_period_end, will_renew, updated_at'
+        )
+        .eq('user_id', user.id)
+        .eq('entitlement', PREMIUM_ENTITLEMENT)
+        .maybeSingle();
+      setEntitlement((data as UserEntitlement | null) ?? null);
+    } catch {
+      setEntitlement(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (authLoading) return;
+    setLoading(true);
+    fetchEntitlement();
+  }, [authLoading, fetchEntitlement]);
+
+  return {
+    isPremium: isEntitlementActive(entitlement),
+    entitlement,
+    loading: authLoading || loading,
+    refetch: fetchEntitlement,
+  };
+}
+
+export default usePremium;

--- a/src/lib/billing/entitlements.ts
+++ b/src/lib/billing/entitlements.ts
@@ -1,0 +1,82 @@
+/**
+ * Premium subscription entitlements.
+ *
+ * RevenueCat is the billing system of record (Apple IAP in the iOS app,
+ * RevenueCat Web Billing on the web). Its webhooks mirror subscription state
+ * into the `user_entitlements` table (see migration 0005), and the app checks
+ * premium status with a plain RLS-protected query via these helpers.
+ */
+
+export const PREMIUM_ENTITLEMENT = 'premium';
+
+export type EntitlementStatus =
+  | 'active'
+  | 'trialing'
+  | 'cancelled'
+  | 'billing_issue'
+  | 'expired';
+
+export interface UserEntitlement {
+  entitlement_id: string;
+  user_id: string;
+  entitlement: string;
+  status: EntitlementStatus;
+  store: string;
+  product_id?: string | null;
+  current_period_end?: string | null;
+  will_renew: boolean;
+  updated_at?: string;
+}
+
+/**
+ * Whether an entitlement row currently grants access.
+ *
+ * 'cancelled' only means auto-renew was turned off — the paid period keeps
+ * running until current_period_end, so it still grants access until then.
+ * A missing current_period_end (promotional / lifetime grants) never expires.
+ */
+export function isEntitlementActive(
+  row: Pick<UserEntitlement, 'status' | 'current_period_end'> | null | undefined,
+  now: Date = new Date()
+): boolean {
+  if (!row) return false;
+  if (row.status === 'expired') return false;
+  if (!row.current_period_end) {
+    return row.status === 'active' || row.status === 'trialing';
+  }
+  return new Date(row.current_period_end).getTime() > now.getTime();
+}
+
+/**
+ * RevenueCat Web Billing purchase link for the premium plan, bound to a
+ * Supabase user id so the webhook can attribute the purchase. Purchase links
+ * accept the app user id as a path segment: https://pay.rev.cat/<id>/<user>.
+ * Returns null until NEXT_PUBLIC_PREMIUM_CHECKOUT_URL is configured.
+ */
+export function premiumCheckoutUrl(userId: string): string | null {
+  const base = process.env.NEXT_PUBLIC_PREMIUM_CHECKOUT_URL;
+  if (!base) return null;
+  return `${base.replace(/\/$/, '')}/${encodeURIComponent(userId)}`;
+}
+
+/** What the premium tier includes — single source for paywall/pricing copy. */
+export const PREMIUM_FEATURES = [
+  {
+    name: 'Wellness trends',
+    description: 'Charts of energy, sleep, and mood over time from your daily logs.',
+  },
+  {
+    name: 'Efficacy insights',
+    description: 'See which supplements correlate with how you actually feel.',
+  },
+  {
+    name: 'Restock reminders',
+    description: 'Know when each container runs out based on your logging pace.',
+  },
+  {
+    name: 'Cost analytics',
+    description: 'Monthly and annual spend breakdowns across your whole regimen.',
+  },
+] as const;
+
+export const PREMIUM_PRICE_LABEL = '$4.99/mo';

--- a/supabase/migrations/20260101000005_billing.sql
+++ b/supabase/migrations/20260101000005_billing.sql
@@ -1,0 +1,69 @@
+-- ============================================================================
+-- 0005 · Billing (premium subscription entitlements)
+-- Depends on 0001 (auth.users via Supabase).
+--
+-- Subscriptions are sold through RevenueCat (Apple IAP in the iOS app,
+-- RevenueCat Web Billing on the web). RevenueCat is the billing system of
+-- record; this table is a mirror kept in sync by the
+-- /api/billing/revenuecat webhook so the app can check premium status with
+-- a plain RLS-protected query — no client billing SDK required on web.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS user_entitlements (
+  entitlement_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Entitlement identifier as configured in RevenueCat (e.g. 'premium').
+  entitlement VARCHAR(60) NOT NULL DEFAULT 'premium',
+
+  -- active | trialing | cancelled | billing_issue | expired
+  -- 'cancelled' means auto-renew is off but the paid period may still be
+  -- running; access checks must also consult current_period_end.
+  status VARCHAR(30) NOT NULL,
+
+  -- app_store | play_store | stripe | rc_billing | promotional | unknown
+  store VARCHAR(30) NOT NULL DEFAULT 'unknown',
+  product_id VARCHAR(120),
+
+  -- RevenueCat app_user_id (we configure clients so this equals user_id).
+  rc_app_user_id VARCHAR(120),
+
+  current_period_end TIMESTAMP WITH TIME ZONE,
+  will_renew BOOLEAN NOT NULL DEFAULT false,
+
+  -- Raw context from the most recent webhook event (event type, period type,
+  -- environment) for debugging billing questions.
+  metadata JSONB DEFAULT '{}'::jsonb,
+
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+  UNIQUE (user_id, entitlement)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_entitlements_user_id
+  ON user_entitlements(user_id);
+
+-- Keep updated_at fresh on every webhook-driven upsert.
+CREATE OR REPLACE FUNCTION update_user_entitlements_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_user_entitlements_updated_at ON user_entitlements;
+CREATE TRIGGER trigger_user_entitlements_updated_at
+  BEFORE UPDATE ON user_entitlements
+  FOR EACH ROW EXECUTE FUNCTION update_user_entitlements_updated_at();
+
+-- RLS: users may read their own entitlement rows. All writes go through the
+-- webhook route using the service-role key (which bypasses RLS) — clients
+-- must never be able to grant themselves premium.
+ALTER TABLE user_entitlements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_entitlements FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view own entitlements" ON user_entitlements;
+CREATE POLICY "Users can view own entitlements" ON user_entitlements
+  FOR SELECT USING (auth.uid() = user_id);

--- a/supabase/migrations/README.md
+++ b/supabase/migrations/README.md
@@ -9,6 +9,7 @@ schema. Each file is an ordered, idempotent migration.
 | 0002 | `20260101000002_commerce.sql` | Shopify/UCP + API-sourcing columns on `supplements`/`products`, `commerce_checkout_events` (RLS-locked, service-role only), `shopify_merchant_capabilities`. |
 | 0003 | `20260101000003_reviews.sql` | `product_reviews`, `review_votes`, `review_images`, `product_rating_stats`, aggregate triggers, RLS. |
 | 0004 | `20260101000004_tracking.sql` | `supplement_logs`, `user_supplement_settings`, `daily_tracking_summary`, streak/summary triggers, RLS. |
+| 0005 | `20260101000005_billing.sql` | `user_entitlements` (premium subscription mirror written by the RevenueCat webhook; RLS: users read own row, service-role writes). |
 
 ## Applying
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the consumer subscription layer (monetization option #2): the marketplace, wiki, stacks, and daily logging stay free, while the personal analytics — wellness trends, efficacy insights, restock reminders — become **SuppStack Premium** ($4.99/mo). RevenueCat is the billing system of record so one subscription works across web (Web Billing/Stripe, ~3% fees) and the upcoming iOS app (Apple IAP via the official Capacitor SDK).

## Architecture

```
Web:  /premium → RevenueCat Web Billing purchase link
iOS:  @revenuecat/purchases-capacitor → Apple IAP (wire into branch cursor/ios-app-store-c1c7)
                      │
                      ▼
     RevenueCat webhook → POST /api/billing/revenuecat
                      │    (Authorization guarded, service-role writes)
                      ▼
     user_entitlements table (migration 0005; RLS: users read own row)
                      │
                      ▼
     usePremium() hook → <PremiumGate> around premium features
```

- **Server-authoritative:** clients can only read their entitlement row; every write goes through the webhook with `SUPABASE_SERVICE_ROLE_KEY`. Nobody can grant themselves premium from the browser.
- **Cross-platform entitlement:** clients identify to RevenueCat with the Supabase user id as `app_user_id`, so a web purchase unlocks iOS and vice versa.
- **Correct cancellation semantics:** `cancelled` (auto-renew off) keeps access until `current_period_end`; only `EXPIRATION` locks the features.
- **Graceful before configuration:** until the RevenueCat env vars are set, the pricing page shows "launching soon" and mapped webhook events return 503 (so RevenueCat retries); TEST pings and anonymous-id events are acknowledged without writes.

## What's included

- `supabase/migrations/20260101000005_billing.sql` — `user_entitlements` mirror with `updated_at` trigger, RLS enabled + forced, upsert key `(user_id, entitlement)`
- `POST /api/billing/revenuecat` — webhook receiver mapping purchase/renewal/uncancellation/cancellation/billing-issue/expiration events onto entitlement status
- `src/lib/billing/entitlements.ts` — entitlement model, `isEntitlementActive`, Web Billing checkout URL helper, premium feature list (single source of pricing copy)
- `usePremium` hook + `PremiumGate` component (skeleton while loading to avoid flashing the paywall at paying members)
- Profile → Insights tab now gates WellnessTrends / EfficacyInsights / RestockReminders; logging and journal stay free
- `/premium` pricing page with free-vs-premium comparison and sign-in / upgrade / member states; Header + Footer link to it
- `PREMIUM_BILLING.md` setup guide and `.env.example` additions

## Validation

- `tsc --noEmit`, lint, and `npm run build` pass; `/premium` prerenders and `/api/billing/revenuecat` registers
- Migration applied to a local Postgres 16 with all prior migrations, re-run to confirm idempotency; verified RLS flags (`relrowsecurity=t`, `relforcerowsecurity=t`), the upsert conflict target, and the `updated_at` trigger
- Webhook smoke-tested against a local production server: 401 on missing/wrong auth, `{ignored:"TEST"}` for test pings, `{ignored:"unmapped app_user_id"}` for anonymous purchasers, 503 for mapped events when storage credentials are absent

## To go live (manual steps)

1. Create the RevenueCat project with a `premium` entitlement + `premium_monthly` product ($4.99/mo) on Web Billing
2. Point the RevenueCat webhook at `/api/billing/revenuecat` with the shared auth token
3. Set `REVENUECAT_WEBHOOK_AUTH_TOKEN`, `NEXT_PUBLIC_PREMIUM_CHECKOUT_URL`, (optional) `NEXT_PUBLIC_PREMIUM_MANAGE_URL` on Vercel
4. Apply migration 0005 (`supabase db push`)
5. When the iOS branch ships: add the App Store Connect subscription and the Capacitor SDK per `PREMIUM_BILLING.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f27bd-1375-77df-bd48-13ff1de1c1c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f27bd-1375-77df-bd48-13ff1de1c1c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

